### PR TITLE
Include cstring

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -10,6 +10,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <string.h>
 
 #define MICROPROFILE_MAX_COUNTERS 512
 #define MICROPROFILE_MAX_COUNTER_NAME_CHARS (MICROPROFILE_MAX_COUNTERS*16)


### PR DESCRIPTION
It seems with gcc/g++, a number of functions are not available by default: memset, strcpy, strlen, strcasecmp resulting in a number of "xyz not declared n this scope"
As a fix microprofile.cpp should either include <string.h>, or the c++ version <cstring>