### PR TITLE
Fix OpenGL GPU profiling + use _aligned_free on Windows

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -43,7 +43,7 @@ enum
 #ifndef MICROPROFILE_ALLOC //redefine all if overriding
 #define MICROPROFILE_ALLOC(nSize, nAlign) MicroProfileAllocAligned(nSize, nAlign);
 #define MICROPROFILE_REALLOC(p, s) realloc(p, s)
-#define MICROPROFILE_FREE(p) free(p)
+#define MICROPROFILE_FREE(p) MicroProfileFreeAligned(p)
 #endif
 
 #define MP_ALLOC(nSize, nAlign) MicroProfileAllocInternal(nSize, nAlign)
@@ -131,6 +131,11 @@ void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 	return p;
 }
 
+void MicroProfileFreeAligned(void* p)
+{
+	free(p);
+}
+
 #elif defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -143,6 +148,11 @@ int64_t MicroProfileGetTick();
 void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 {
 	return _aligned_malloc(nSize, nAlign);
+}
+
+void MicroProfileFreeAligned(void* p)
+{
+	_aligned_free(p);
 }
 
 #else
@@ -173,6 +183,12 @@ void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 	posix_memalign(&p, nAlign, nSize);
 	return p;
 }
+
+void MicroProfileFreeAligned(void* p)
+{
+	free(p);
+}
+
 #endif
 
 
@@ -7165,6 +7181,7 @@ int MicroProfileGetGpuTickReference(int64_t* pOutCPU, int64_t* pOutGpu)
 #elif MICROPROFILE_GPU_TIMERS_GL
 void MicroProfileGpuInitGL()
 {
+	S.pGPU = MP_ALLOC_OBJECT(MicroProfileGpuTimerState);
 	S.pGPU->GLTimerPos = 0;
 	glGenQueries(MICROPROFILE_GL_MAX_QUERIES, &S.pGPU->GLTimers[0]);		
 }
@@ -7225,6 +7242,18 @@ int MicroProfileGetGpuTickReference(int64_t* pOutCpu, int64_t* pOutGpu)
 	return 0;
 }
 
+uint32_t MicroProfileGpuFlip(void* pContext)
+{
+	uint32_t nFrameTimeStamp = MicroProfileGpuInsertTimeStamp(pContext);
+	return nFrameTimeStamp;
+}
+
+void MicroProfileGpuShutdown()
+{
+	glDeleteQueries(MICROPROFILE_GL_MAX_QUERIES, &S.pGPU->GLTimers[0]);
+	MP_FREE(S.pGPU);
+	S.pGPU = 0;
+}
 
 #endif
 

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -43,7 +43,7 @@ enum
 #ifndef MICROPROFILE_ALLOC //redefine all if overriding
 #define MICROPROFILE_ALLOC(nSize, nAlign) MicroProfileAllocAligned(nSize, nAlign);
 #define MICROPROFILE_REALLOC(p, s) realloc(p, s)
-#define MICROPROFILE_FREE(p) free(p)
+#define MICROPROFILE_FREE(p) MicroProfileFreeAligned(p)
 #endif
 
 #define MP_ALLOC(nSize, nAlign) MicroProfileAllocInternal(nSize, nAlign)
@@ -131,6 +131,11 @@ void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 	return p;
 }
 
+void MicroProfileFreeAligned(void* p)
+{
+    free(p);
+}
+
 #elif defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -143,6 +148,11 @@ int64_t MicroProfileGetTick();
 void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 {
 	return _aligned_malloc(nSize, nAlign);
+}
+
+void MicroProfileFreeAligned(void* p)
+{
+    _aligned_free(p);
 }
 
 #else
@@ -173,6 +183,12 @@ void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 	posix_memalign(&p, nAlign, nSize);
 	return p;
 }
+
+void MicroProfileFreeAligned(void* p)
+{
+    free(p);
+}
+
 #endif
 
 
@@ -5920,7 +5936,7 @@ void MicroProfileWin32ExtractModules(MicroProfileWin32ThreadInfo::Process& P)
 void MicroProfileWin32InitThreadInfo2()
 {
 	memset(&g_ThreadInfo, 0, sizeof(g_ThreadInfo));
-	float fToMsCpu = MicroProfileTickToMsMultiplier(MicroProfileTicksPerSecondCpu());
+    float fToMsCpu = MicroProfileTickToMsMultiplier(MicroProfileTicksPerSecondCpu());
 
 	HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0);
 	PROCESSENTRY32 pe32;
@@ -5928,7 +5944,7 @@ void MicroProfileWin32InitThreadInfo2()
 	te32.dwSize = sizeof(THREADENTRY32);
 	pe32.dwSize = sizeof(PROCESSENTRY32);
 	{
-		int64_t nTickStart = MP_TICK();
+        int64_t nTickStart = MP_TICK();
 		if (Process32First(hSnap, &pe32))
 		{
 			do
@@ -5947,7 +5963,7 @@ void MicroProfileWin32InitThreadInfo2()
 #endif
 	}
 	{
-		int64_t nTickStart = MP_TICK();
+        int64_t nTickStart = MP_TICK();
 		for (uint32_t i = 0; i < g_ThreadInfo.nNumProcesses; ++i)
 		{
 			uint32_t pid = g_ThreadInfo.P[i].pid;
@@ -5972,7 +5988,7 @@ void MicroProfileWin32InitThreadInfo2()
 
 	if (Thread32First(hSnap, &te32))
 	{
-		int64_t nTickStart = MP_TICK();
+        int64_t nTickStart = MP_TICK();
 		do
 		{
 			nThreadsTested++;
@@ -7165,8 +7181,9 @@ int MicroProfileGetGpuTickReference(int64_t* pOutCPU, int64_t* pOutGpu)
 #elif MICROPROFILE_GPU_TIMERS_GL
 void MicroProfileGpuInitGL()
 {
-	S.pGPU->GLTimerPos = 0;
-	glGenQueries(MICROPROFILE_GL_MAX_QUERIES, &S.pGPU->GLTimers[0]);		
+    S.pGPU = MP_ALLOC_OBJECT(MicroProfileGpuTimerState);
+    S.pGPU->GLTimerPos = 0;
+	glGenQueries(MICROPROFILE_GL_MAX_QUERIES, &S.pGPU->GLTimers[0]);
 }
 
 uint32_t MicroProfileGpuInsertTimeStamp(void* pContext)
@@ -7225,6 +7242,18 @@ int MicroProfileGetGpuTickReference(int64_t* pOutCpu, int64_t* pOutGpu)
 	return 0;
 }
 
+uint32_t MicroProfileGpuFlip(void* pContext)
+{
+    uint32_t nFrameTimeStamp = MicroProfileGpuInsertTimeStamp(pContext);
+    return nFrameTimeStamp;
+}
+
+void MicroProfileGpuShutdown()
+{
+    glDeleteQueries(MICROPROFILE_GL_MAX_QUERIES, &S.pGPU->GLTimers[0]);
+    MP_FREE(S.pGPU);
+    S.pGPU = 0;
+}
 
 #endif
 


### PR DESCRIPTION
As discussed in Issue #8 , OpenGL profiling was broken due to two functions being left unimplemented.

As I said in my reply in that issue, I'm not sure the implementations I've given are complete, only that they work for me.

I've also included another change -- since MICROPROFILE_ALLOC() uses _aligned_malloc() on Windows, MICROPROFILE_FREE() should use _aligned_free(). On VS2017 at least, I would get an assert when free() was called otherwise. I wondered if this was something new for VS2017, but _aligned_free seems to exist since VS .NET 2003 so it should be fine.

Sorry for the multiple commits. My first commit didn't preserve tabs for indentation (I use 4 spaces) so it showed useless whitespace changes. The last commit looks fine.