### PR TITLE
Fix GPU log stack corruption

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -1138,6 +1138,7 @@ void MicroProfileThreadLogGpuReset(MicroProfileThreadLogGpu* pLog)
 	pLog->pContext = (void*)-1;
 	pLog->nStart = (uint32_t)-1;
 	pLog->nPut = 0;
+	pLog->nStackScope = 0;
 }
 
 MicroProfileThreadLogGpu* MicroProfileThreadLogGpuAllocInternal()


### PR DESCRIPTION
It seems that the MicroProfileThreadLogGpu structure is not initialized to zero when allocated, which can result in nStackScope not being zero at the beginning of the program. This results in the thread log stack starting at a garbage index.
I added a line to initialize the value appropriately in the Reset function.
This might just be me misusing the library, and I'm not sure if my patch here is the proper way to do it, but it fixed all the issues I had.