### PR TITLE
fix warnings

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -2532,8 +2532,7 @@ void MicroProfileFlip(void* pContext)
 
 							if(MP_LOG_ENTER == nType)
 							{
-								int nTimer = MicroProfileLogGetTimerIndex(LE);
-								MP_ASSERT(nTimer>=0);
+								uint64_t nTimer = MicroProfileLogGetTimerIndex(LE);
 								MP_ASSERT(nTimer < S.nTotalTimers);
 								uint32_t nGroup = pTimerToGroup[nTimer];
 								MP_ASSERT(nStackPos < MICROPROFILE_STACK_MAX);
@@ -2546,7 +2545,7 @@ void MicroProfileFlip(void* pContext)
 							}
 							else if(MP_LOG_LEAVE == nType)
 							{
-								int nTimer = MicroProfileLogGetTimerIndex(LE);
+								uint64_t nTimer = MicroProfileLogGetTimerIndex(LE);
 								MP_ASSERT(nTimer < S.nTotalTimers);
 								MP_ASSERT(nTimer >= 0);
 								uint32_t nGroup = pTimerToGroup[nTimer];

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -169,7 +169,11 @@ typedef uint64_t MicroProfileThreadIdType;
 void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 {
 	void* p; 
-	posix_memalign(&p, nAlign, nSize); 
+	int result = posix_memalign(&p, nAlign, nSize); 
+	if (result != 0)
+	{
+		return nullptr;
+	}
 	return p;
 }
 
@@ -222,7 +226,11 @@ typedef uint64_t MicroProfileThreadIdType;
 void* MicroProfileAllocAligned(size_t nSize, size_t nAlign)
 {
 	void* p;
-	posix_memalign(&p, nAlign, nSize);
+	int result = posix_memalign(&p, nAlign, nSize);
+	if (result != 0)
+	{
+		return nullptr;
+	}
 	return p;
 }
 void MicroProfileFreeAligned(void* pMem)

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -1815,13 +1815,13 @@ void MicroProfileTimelineLeaveStatic(const char* pStr)
 	}
 }
 
-uint32_t MicroProfileTimelineEnterInternal(uint32_t nColor, const char* pStr, int nStrLen, int bIsStaticString)
+uint32_t MicroProfileTimelineEnterInternal(uint32_t nColor, const char* pStr, size_t nStrLen, int bIsStaticString)
 {
 	std::lock_guard<std::recursive_mutex> Lock(MicroProfileTimelineMutex());
 	MicroProfileThreadLog* pLog = &S.TimelineLog;
 	MP_ASSERT(pStr[nStrLen] == '\0');
-	uint32_t nStringQwords = (nStrLen + 6) / 7;
-	uint32_t nNumMessages = nStringQwords;
+	size_t nStringQwords = (nStrLen + 6) / 7;
+	size_t nNumMessages = nStringQwords;
 
 	uint32_t nPut = pLog->nPut.load(std::memory_order_relaxed);
 	uint32_t nNextPos = (nPut + 1) % MICROPROFILE_BUFFER_SIZE;
@@ -1866,10 +1866,10 @@ uint32_t MicroProfileTimelineEnterInternal(uint32_t nColor, const char* pStr, in
 		pLog->Log[nPut++] = LEEnter; nPut %= MICROPROFILE_BUFFER_SIZE;
 		pLog->Log[nPut++] = LEColor; nPut %= MICROPROFILE_BUFFER_SIZE;
 		pLog->Log[nPut++] = LEId; nPut %= MICROPROFILE_BUFFER_SIZE;
-		int nCharsLeft = nStrLen;
+		size_t nCharsLeft = nStrLen;
 		while(nCharsLeft>0)
 		{
-			int nCount = MicroProfileMin(nCharsLeft, 7);
+			size_t nCount = MicroProfileMin(nCharsLeft, (size_t)7);
 			uint64_t LEPayload = MicroProfileMakeLogPayload(pStr, nCount);
 			pLog->Log[nPut++] = LEPayload; nPut %= MICROPROFILE_BUFFER_SIZE;
 			pStr += nCount;

--- a/microprofile.h
+++ b/microprofile.h
@@ -34,6 +34,8 @@
 #define MICROPROFILE_ONCE
 
 #include <stdint.h>
+#include <stddef.h>
+
 #if defined(_WIN32) && _MSC_VER == 1700
 #define PRIx64 "llx"
 #define PRIu64 "llu"
@@ -436,7 +438,7 @@ MICROPROFILE_API void MicroProfileEnter(MicroProfileToken nToken);
 MICROPROFILE_API void MicroProfileLeave();
 MICROPROFILE_API void MicroProfileEnterGpu(MicroProfileToken nToken, struct MicroProfileThreadLogGpu* pLog);
 MICROPROFILE_API void MicroProfileLeaveGpu(struct MicroProfileThreadLogGpu* pLog);
-MICROPROFILE_API uint32_t MicroProfileTimelineEnterInternal(uint32_t nColor, const char* pStr, int nStrLen, int bIsStaticString);
+MICROPROFILE_API uint32_t MicroProfileTimelineEnterInternal(uint32_t nColor, const char* pStr, size_t nStrLen, int bIsStaticString);
 MICROPROFILE_API uint32_t MicroProfileTimelineEnter(uint32_t nColor, const char* pStr);
 MICROPROFILE_API uint32_t MicroProfileTimelineEnterf(uint32_t nColor, const char* pStr, ...);
 MICROPROFILE_API void MicroProfileTimelineLeave(uint32_t id);


### PR DESCRIPTION
- The return value of `posix_memalign` apparently cannot be ignored or a warning is emitted.
  This fixes this warning:
  ```
  microprofile/microprofile/microprofile.cpp:225:16: warning: ignoring return value of 'int 
  posix_memalign(void**, size_t, size_t)', declared with attribute warn_unused_result [-Wunused-result]
  ```
  See this [travis log](https://travis-ci.org/madebr/openrw/jobs/424363544#L2843) for reference.
- By calling the function `MicroProfileTimelineEnterInternal` with a size_t argument, a warning of possible loss of data is emitted.
  This fixes these warnings:
  ```
  c:\projects\openrw\external\microprofile\microprofile\microprofile.cpp(1796): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\openrw\build\external\microprofile\microprofile.vcxproj]
  c:\projects\openrw\external\microprofile\microprofile\microprofile.cpp(1880): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\openrw\build\external\microprofile\microprofile.vcxproj]
  c:\projects\openrw\external\microprofile\microprofile\microprofile.cpp(1896): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data 
  ```
  See this [appveyor log](https://ci.appveyor.com/project/madebr/openrw/build/1.0.943#L439) for reference
- MicroProfileLogGetTimerIndex returns a uint64_t (which is unsigned), this fixed the `<` comparison between a signed and unsigned integer a line later.
  This fixes thes warnings:
  ```
  c:\projects\openrw\external\microprofile\microprofile\microprofile.cpp(2529): warning C4018: '<': signed/unsigned mismatch [C:\projects\openrw\build\external\microprofile\microprofile.vcxproj]
  c:\projects\openrw\external\microprofile\microprofile\microprofile.cpp(2542): warning C4018: '<': signed/unsigned mismatch [C:\projects\openrw\build\external\microprofile\microprofile.vcxproj]
  ```
  See this [appveyor log](https://ci.appveyor.com/project/madebr/openrw/build/1.0.943#L442) for reference