### PR TITLE
Fixed displaying of first scope in timeline

### DIFF
--- a/microprofile_html.h
+++ b/microprofile_html.h
@@ -6669,7 +6669,7 @@ const char g_MicroProfileHtml_end_4[] =
 "			Pairs[i] = -1;\n"
 "			var ID = Ids[i];\n"
 "			var match = Matching[ID];\n"
-"			if(match)\n"
+"			if(match != null)\n"
 "			{\n"
 "				if(match > Ids.length || match < 0)\n"
 "					debugger;\n"


### PR DESCRIPTION
This fixed an issue when I had one time line scope in my capture, but it was never displayed.