### PR TITLE
Do not use pGPU on shutdown if GPU profiling was never initialized.

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -1504,7 +1504,10 @@ void MicroProfileShutdown()
 			S.pJsonSettings = 0;
 			S.nJsonSettingsBufferSize = 0;
 		}
-		MicroProfileGpuShutdown();
+		if (S.pGPU)
+		{
+			MicroProfileGpuShutdown();
+		}
 		MicroProfileHashTableDestroy(&S.Strings.HashTable);
 		MicroProfileStringsDestroy(&S.Strings);
 		MICROPROFILE_FREE_NON_ALIGNED(S.WSBuf.pBufferAllocation);


### PR DESCRIPTION
This is useful for console applications that do not have a context and will not use GPU profiling at all. MicroProfileGpuShutdown() (D3D11) uses pGPU and the query objects inside unconditionally.

Previously I would have used a version of MicroProfile compiled with GPU profiling disabled, but in this case I want to use the same lib for two apps, one of which uses GPU profiling and the other which doesn't.

pGPU is initialized to 0 when the g_MicroProfile is memset to 0 in MicroProfileInit(). In all other ways it seems fine for GPU profiling to be optional (i.e. don't call MicroProfileGpuInit{API}() if you don't need it).