### PR TITLE
Fixed live view issue with locales other than POSIX

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -1281,17 +1281,16 @@ char* MicroProfileDToStr(float value)
   memset(g_FloatToStr, 0, 64);
   char tmp[64];
   memset(tmp, 0, 64);
-  sprintf(tmp, "%f", value);
+  snprintf(tmp, 64, "%f", value);
   const struct lconv* loc = localeconv();
   char* p = &tmp[0];
   char* q = &g_FloatToStr[0];
   while(*p)
   {
-    if (*p != loc->thousands_sep[0])
-      *q = *p;
     if (*p == loc->decimal_point[0])
-      *q = '.';
-    ++q;
+      *p = '.';
+    if (*p != loc->thousands_sep[0])
+      *q++ = *p;
     ++p;
   }
   return g_FloatToStr;


### PR DESCRIPTION
Live view doesn't work in any browser since floating point data (stored in JSON) has been sent
using current user locale with LC_NUMERIC other than POSIX format (when
floating point contains delimiter other than dot and/or contains thousand delimiters). However 
JSON format requires POSIX floating point format.

This fix doesn't use setlocale() as it is not thread safe. Instead it uses simple but efficient approach. 
This will work with most locales except exotic where decimal delimiter and thousand separator 
are stored in more than 1 character.

Also this changes are safe since new functionality could be switched on/off using macro.