### PR TITLE
Fix VS2019 compile errors

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -7309,7 +7309,7 @@ void MicroProfileContextSwitchShutdownTrace()
 
 	EVENT_TRACE_LOGFILE log;
 	ZeroMemory(&log, sizeof(log));
-	log.LoggerName = KERNEL_LOGGER_NAME;
+	log.LoggerName = (LPSTR)KERNEL_LOGGER_NAME;
 	log.ProcessTraceMode = 0;
 	TRACEHANDLE hLog = OpenTrace(&log);
 	if (hLog)
@@ -7354,7 +7354,7 @@ bool MicroProfileStartWin32Trace(EventCallback EvtCb, BufferCallback BufferCB)
 	EVENT_TRACE_LOGFILE log;
 	ZeroMemory(&log, sizeof(log));
 
-	log.LoggerName = KERNEL_LOGGER_NAME;
+	log.LoggerName = (LPSTR)KERNEL_LOGGER_NAME;
 	log.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
 	log.EventCallback = EvtCb;
 	log.BufferCallback = BufferCB;

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -11383,6 +11383,8 @@ BOOL MicroProfileQueryContextEnumSymbols (
 };
 
 
+bool MicroProfileSymInit();
+void MicroProfileSymCleanup();
 
 template<typename Callback>
 void MicroProfileIterateSymbols(Callback CB, uint32_t* nModules, uint32_t nNumModules)


### PR DESCRIPTION
These fixes are needed for me to build microprofile with the latest VS2019 update (MSVC 19.28.29333). Cheers!