### PR TITLE
Add basic CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ generate_export_header(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC MICROPROFILE_EXPORT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.4)
+project(microprofile)
+
+option(MICROPROFILE_USE_CONFIG_FILE "Use user provided configuration in microprofile.config.h file." OFF)
+
+set(MICROPROFILE_EXPORT_FILENAME microprofile.export.h)
+set(MICROPROFILE_CONFIG_HEADER ${PROJECT_SOURCE_DIR}/microprofile.config.h)
+set(MICROPROFILE_PUBLIC_HEADERS
+        ${PROJECT_SOURCE_DIR}/microprofile.h
+        ${CMAKE_CURRENT_BINARY_DIR}/${MICROPROFILE_EXPORT_FILENAME}
+)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+add_library(${PROJECT_NAME} microprofile.cpp)
+
+include(GenerateExportHeader)
+generate_export_header(${PROJECT_NAME}
+        EXPORT_MACRO_NAME MICROPROFILE_API
+        EXPORT_FILE_NAME ${MICROPROFILE_EXPORT_FILENAME}
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_compile_definitions(${PROJECT_NAME} PUBLIC MICROPROFILE_EXPORT)
+
+if (MICROPROFILE_USE_CONFIG_FILE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC MICROPROFILE_USE_CONFIG)
+endif()
+
+find_package(Threads REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
+
+if (WIN32)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
+endif()
+
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${MICROPROFILE_PUBLIC_HEADERS}")
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+if (MICROPROFILE_USE_CONFIG_FILE)
+    install(FILES ${MICROPROFILE_CONFIG_HEADER}
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+    )
+endif()

--- a/microprofile.h
+++ b/microprofile.h
@@ -192,8 +192,12 @@ typedef uint16_t MicroProfileGroupId;
 
 #include <stdint.h>
 
+#ifdef MICROPROFILE_EXPORT
+#include "microprofile.export.h"
+#else
 #ifndef MICROPROFILE_API
 #define MICROPROFILE_API
+#endif
 #endif
 
 #ifdef MICROPROFILE_PS4
@@ -359,7 +363,7 @@ typedef void (*MicroProfileOnFreeze)(int nFrozen);
 #endif
 
 #ifndef MICROPROFILE_GPU_TIMERS
-#define MICROPROFILE_GPU_TIMERS 1
+#define MICROPROFILE_GPU_TIMERS 0
 #endif
 
 #ifndef MICROPROFILE_GPU_TIMER_CALLBACKS


### PR DESCRIPTION
Adds basic support for CMake to compile this library.

- Config file `microprofile.config.h` can be provided by setting the `MICROPROFILE_USE_CONFIG_FILE` option to `ON`.
- I also changed default value of `MICROPROFILE_GPU_TIMERS` define to `0` so the project can be compiled without config changes.
- Added `generate_export_header` in CMake so that `__declspec(dllexport)` and `__declspec(dllimport)` are automatically provided for Windows when using CMake. Exported file with these definitions is called `microprofile.export.h`.