### PR TITLE
build: use system stb when possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,15 @@ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${MICROPROFILE_PUBLIC_HEADERS}")
 
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+	pkg_check_modules(stb QUIET IMPORTED_TARGET stb)
+endif()
+if (stb_FOUND)
+	target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::stb)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE MICROPROFILE_SYSTEM_STB)
+endif()
+
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -43,8 +43,12 @@ void MicroProfileGpuSetCallbacks(
 #include <ctype.h>
 #include <string.h>
 
+#if defined(MICROPROFILE_SYSTEM_STB)
+#include <stb_sprintf.h>
+#else
 #define STB_SPRINTF_IMPLEMENTATION
 #include "stb/stb_sprintf.h"
+#endif
 
 
 #if defined(_WIN32) && _MSC_VER == 1700

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -3930,11 +3930,11 @@ struct MicroProfilePrintfArgs
 
 };
 
-char* MicroProfilePrintfCallback(char* buf, void* user, int len)
+char* MicroProfilePrintfCallback(const char* buf, void* user, int len)
 {
 	MicroProfilePrintfArgs* A = (MicroProfilePrintfArgs*)user;
 	(A->CB)(A->Handle, len, buf);
-	return buf;
+	return const_cast<char*>(buf);
 };
 
 void MicroProfilePrintf(MicroProfileWriteCallback CB, void* Handle, const char* pFmt, ...)
@@ -6878,7 +6878,7 @@ void MicroProfileResizeWSBuf(uint32_t nMinSize = 0)
 	S.WSBuf.nBufferSize = nNewSize - 20;
 }
 
-char* MicroProfileWSPrintfCallback(char* buf, void* user, int len)
+char* MicroProfileWSPrintfCallback(const char* buf, void* user, int len)
 {
 	MP_ASSERT(S.WSBuf.nPut == buf - S.WSBuf.pBuffer);
 	S.WSBuf.nPut += len;


### PR DESCRIPTION
This patch allows microprofile to automatically use system's libstb when available. This is particularly useful in Linux distributions, where libraries are easily discoverable with the use of pkg-config and similar, and also for packaging, since downstream distributions prefer to use shared libraries when possible.

I had to add an `#if defined MICROPROFILE_SYSTEM_STB` in microprofile.cpp because when linking against a precompiled stb the `STB_SPRINTF_IMPLEMENTATION` macro doesn't have to be defined and also to avoid header clashes, because `#include "stb/stb_sprintf.h"` would use the headers from the submodule even if the system one is wanted.

This doesn't change anything for users that are not using CMake.