### PR TITLE
Type correctness fixes

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -4715,11 +4715,11 @@ void MicroProfileDumpHtml(MicroProfileWriteCallback CB, void* Handle, uint64_t n
 			{
 				ThreadId = (MicroProfileThreadIdType)-1;
 			}
-			MicroProfilePrintf(CB, Handle, "%d,", ThreadId);
+			MicroProfilePrintf(CB, Handle, "%" PRIu64 ",", (uint64_t)ThreadId);
 		}
 		else
 		{
-			MicroProfilePrintf(CB, Handle, "-1,", i);
+			MicroProfilePrintf(CB, Handle, "-1,");
 		}
 	}
 	MicroProfilePrintf(CB, Handle, "];\n\n");

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -138,7 +138,7 @@ template <typename T>
 T MicroProfileClamp(T a, T min_, T max_);
 int64_t MicroProfileMsToTick(float fMs, int64_t nTicksPerSecond);
 float MicroProfileTickToMsMultiplier(int64_t nTicksPerSecond);
-uint64_t MicroProfileLogGetType(MicroProfileLogEntry Index);
+uint32_t MicroProfileLogGetType(MicroProfileLogEntry Index);
 uint64_t MicroProfileLogGetTimerIndex(MicroProfileLogEntry Index);
 MicroProfileLogEntry MicroProfileMakeLogIndex(uint64_t nBegin, MicroProfileToken nToken, int64_t nTick);
 int64_t MicroProfileLogTickDifference(MicroProfileLogEntry Start, MicroProfileLogEntry End);
@@ -1052,7 +1052,7 @@ struct MicroProfile
 	MicroProfileGpuTimerState* pGPU;
 };
 
-inline uint64_t MicroProfileLogGetType(MicroProfileLogEntry Index)
+inline uint32_t MicroProfileLogGetType(MicroProfileLogEntry Index)
 {
 	return ((MP_LOG_BEGIN_MASK & Index) >> 62) & 0x3;
 }
@@ -1101,7 +1101,7 @@ MicroProfileLogEntry MicroProfileMakeLogExtendedNoData(EMicroProfileTokenExtende
 inline MicroProfileLogEntry MicroProfileMakeLogIndex(uint64_t nBegin, MicroProfileToken nToken, int64_t nTick)
 {
 	MicroProfileLogEntry Entry = (nBegin << 62) | ((0x3fff & nToken) << 48) | (MP_LOG_TICK_MASK & nTick);
-	uint64_t t = MicroProfileLogGetType(Entry);
+	uint32_t t = MicroProfileLogGetType(Entry);
 	uint64_t nTimerIndex = MicroProfileLogGetTimerIndex(Entry);
 	MP_ASSERT(t == nBegin);
 	MP_ASSERT(nTimerIndex == (nToken & 0x3fff));
@@ -3367,7 +3367,7 @@ void MicroProfileFlip_CB(void* pContext, MicroProfileOnFreeze FreezeCB)
 					{
 						int64_t LE = pLog->Log[nStart];
 						int64_t nDifference = MicroProfileLogTickDifference(LE, nTickEndFrame);
-						uint64_t Ext = MicroProfileLogGetType(LE);
+						uint32_t Ext = MicroProfileLogGetType(LE);
 						if(nDifference > 0 || 0 != (0x2 & Ext))
 						{
 							nStart = (nStart + 1) % MICROPROFILE_BUFFER_SIZE;
@@ -3510,7 +3510,7 @@ void MicroProfileFlip_CB(void* pContext, MicroProfileOnFreeze FreezeCB)
 						for(uint32_t k = nStart; k < nEnd; ++k)
 						{
 							MicroProfileLogEntry LE = pLog->Log[k];
-							uint64_t nType = MicroProfileLogGetType(LE);
+							uint32_t nType = MicroProfileLogGetType(LE);
 
 							switch(nType)
 							{
@@ -5019,7 +5019,7 @@ void MicroProfileDumpHtml(MicroProfileWriteCallback CB, void* Handle, uint64_t n
 			int64_t nStartTickBase = pLog->nGpu ? nTickStartGpu : nTickStart;
 			uint32_t nLogStart = S.Frames[nFrameIndex].nLogStart[j];
 			uint32_t nLogEnd = S.Frames[nFrameIndexNext].nLogStart[j];
-			uint64_t nLogType;
+			uint32_t nLogType;
 			float fToMs;
 			uint64_t nStartTick;
 			float fToMsCpu = MicroProfileTickToMsMultiplier(nTicksPerSecondCpu);
@@ -5074,7 +5074,7 @@ void MicroProfileDumpHtml(MicroProfileWriteCallback CB, void* Handle, uint64_t n
 				for(k = (k + 1) % MICROPROFILE_BUFFER_SIZE; k != nLogEnd; k = (k + 1) % MICROPROFILE_BUFFER_SIZE)
 				{
 					uint64_t v = pLog->Log[k];
-					uint64_t nLogType2 = MicroProfileLogGetType(v);
+					uint32_t nLogType2 = MicroProfileLogGetType(v);
 
 					if(nLogType2 > MP_LOG_ENTER)
 						nLogType2 |= (MicroProfileLogGetExtendedToken(v))

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -1338,7 +1338,7 @@ void MicroProfileThreadJoin(MicroProfileThread* pThread)
 }
 #elif defined(_WIN32)
 typedef HANDLE MicroProfileThread;
-DWORD _stdcall ThreadTrampoline(void* pFunc)
+DWORD __stdcall ThreadTrampoline(void* pFunc)
 {
 	MicroProfileThreadFunc F = (MicroProfileThreadFunc)pFunc;
 	return (uint32_t)(uintptr_t)F(0);


### PR DESCRIPTION
This fixes some attempts to print 64-bit integers with `%d`. I decided to narrow the type of `MicroProfileLogGetType` rather than change the format string, since a 64-bit integer for 2 bit flags is way too overkill. We should also consider narrowing other types like `MicroProfileLogGetTimerIndex` which also uses a 64-bit integer even though `MicroProfileGetTimerIndex` returns a 16-bit integer.

Beyond this there are many more type fixes possible, since there's lots of attempts to print unsigned types as signed integers. Shall I address those in this PR as well or should we keep that separate? Also, do you want to use `%PRIu64` or `%lld`? I've seen both usages, we don't really need to use the former since we don't rely on the libc `sprintf`.

Fixes issue #86.