### PR TITLE
Wait for data before async recv

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -8813,6 +8813,10 @@ bool MicroProfileWebServerUpdate()
 	MicroProfileWebSocketFrame();
 	if(!MP_INVALID_SOCKET(Connection))
 	{
+		fd_set readfds;
+		FD_ZERO(&readfds);
+		FD_SET(Connection, &readfds);
+		select(0, &readfds, NULL, NULL, NULL);
 		std::lock_guard<std::recursive_mutex> Lock(MicroProfileMutex());
 		char Req[8192];
 		int nReceived = recv(Connection, Req, sizeof(Req) - 1, 0);


### PR DESCRIPTION
This fixes an issue where recv() is called on a non-blocking socket immediately after accept() before it's ready for reading, returns -1 and the connection is closed.

I found this when I was trying to profile a Windows executable running in Wine on Linux in a Docker container in Kubernetes on AWS. I tried to connect to it from a local web browser via kubectl port-forward and it kept closing the connection 100% of the times. This was the only setup I was able to reproduce it with. I believe the kubectl port-forward was the main trigger for the issue because I didn't observe it when connecting from inside the Docker container.